### PR TITLE
Refactor landing page into modular sections

### DIFF
--- a/karma-aligns-app/components/landing/AstroLanding.tsx
+++ b/karma-aligns-app/components/landing/AstroLanding.tsx
@@ -1,18 +1,21 @@
 'use client';
 
 import React, { useState, useRef, useEffect } from 'react';
-import MotionFade from '@/components/ui/MotionFade';
-import Card from '@/components/ui/Card';
 import SiteHeader from './SiteHeader';
 import Starfield from './Starfield';
 import AmbientBodies from './AmbientBodies';
-import BirthForm, { BirthFormValues } from './BirthForm';
-import Image from 'next/image';
-import Moon from './Moon';
 import ShootingStars from './ShootingStars';
-import SampleButtons from './SampleButtons';
+import Moon from './Moon';
+import ConstellationOverlay from './ConstellationOverlay';
 import SiteFooter from './SiteFooter';
-import { ChevronDown, ArrowUp, Shield, Sparkles, Star, TrendingUp, Users, Award } from 'lucide-react';
+import { ChevronDown, ArrowUp } from 'lucide-react';
+import { BirthFormValues } from './BirthForm';
+import Hero from './Hero';
+import TrustStrip from './TrustStrip';
+import ChartForm from './ChartForm';
+import DemoProfiles from './DemoProfiles';
+import ValueGrid from './ValueGrid';
+import PreviewSection from './PreviewSection';
 
 export default function AstroLanding({ wheelSrc = '/karma-wheel.png' }: { wheelSrc?: string }) {
   const [submitting, setSubmitting] = useState(false);
@@ -20,8 +23,6 @@ export default function AstroLanding({ wheelSrc = '/karma-wheel.png' }: { wheelS
   const [showBackToTop, setShowBackToTop] = useState(false);
   const [showScrollIndicator, setShowScrollIndicator] = useState(true);
   const formRef = useRef<HTMLDivElement>(null);
-  const heroRef = useRef<HTMLDivElement>(null);
-  const headingText = "Balance your Karma, Align your Life."
 
   // Handle scroll to show/hide buttons
   useEffect(() => {
@@ -85,6 +86,8 @@ export default function AstroLanding({ wheelSrc = '/karma-wheel.png' }: { wheelS
       <div className="absolute inset-0 z-0">
         <Starfield />
         <AmbientBodies />
+        <Moon />
+        <ConstellationOverlay />
         <ShootingStars maxActive={3} minDelayMs={1800} maxDelayMs={5200} trigger='auto' />
       </div>
 
@@ -118,126 +121,13 @@ export default function AstroLanding({ wheelSrc = '/karma-wheel.png' }: { wheelS
       {/* Foreground Layer */}
       <div className="relative z-10">
         <SiteHeader />
-
-        {/* Hero Section */}
-        <section id="hero" ref={heroRef} className="relative flex min-h-screen flex-col items-center justify-center p-4 py-8 text-center gap-8">
-
-          <div className="w-full max-w-sm lg:max-w-md">
-            <div className="relative aspect-square group">
-              <Image
-                src={wheelSrc}
-                alt="Zodiac wheel"
-                fill
-                priority
-                className="rounded-full opacity-100 spin-slow group-hover:scale-105 transition-transform duration-700"
-                sizes="(min-width: 1024px) 500px, (min-width: 768px) 400px, 70vw"
-              />
-              {/* Enhanced animated highlight dot */}
-              <div className="absolute left-[68%] top-[44%] h-4 w-4 animate-pulse rounded-full bg-amber-300/90 shadow-[0_0_50px_12px_rgba(251,191,36,.3)]" />
-            </div>
-          </div>
-
-          <div className="w-full space-y-6">
-            <h1 className="font-heading text-5xl md:text-7xl lg:text-8xl font-bold leading-none tracking-tighter text-white hero-heading heading-shadow-container py-4">
-              Balance your <span className="text-fuchsia-400 drop-shadow-[0_0_20px_rgba(217,70,239,0.5)]">Karma</span>
-              <br />
-              <span className="text-fuchsia-400 drop-shadow-[0_0_20px_rgba(217,70,239,0.5)]">Align</span> your life
-            </h1>
-            
-            {/* Enhanced subtitle */}
-            <div className="max-w-3xl mx-auto space-y-4">
-              <p className="text-white/80 text-lg md:text-xl lg:text-2xl font-body leading-relaxed">
-                Discover your cosmic blueprint through personalized astrological insights. 
-                Get your detailed birth chart, planetary positions, and karmic guidance.
-              </p>
-              
-              {/* Social proof */}
-              <div className="flex items-center justify-center gap-6 text-sm text-white/60 pt-4">
-                <div className="flex items-center gap-1">
-                  <Users className="w-4 h-4" />
-                  <span>1000+ charts generated</span>
-                </div>
-                <div className="flex items-center gap-1">
-                  <Star className="w-4 h-4 text-yellow-400" />
-                  <span>4.9/5 rating</span>
-                </div>
-                <div className="flex items-center gap-1">
-                  <Award className="w-4 h-4" />
-                  <span>AI-powered insights</span>
-                </div>
-              </div>
-            </div>
-          </div>
-        </section>
-
-        {/* Birth Form Section */}
+        <Hero wheelSrc={wheelSrc} onCTAClick={scrollToForm} />
+        <TrustStrip />
         <section id="birth-form" ref={formRef} className="container mx-auto py-16 px-4">
-          <MotionFade delay={0.1}>
-            <div className="mx-auto max-w-2xl">
-              <div className="mb-10 space-y-6 text-center">
-                {/* Enhanced heading with better visibility */}
-                <div className="flex items-center justify-center gap-3 mb-6">
-                  <Sparkles className="w-7 h-7 text-fuchsia-400 animate-pulse" />
-                  <h2 className="text-3xl md:text-4xl font-heading font-bold text-white drop-shadow-lg">
-                    Generate Your Chart
-                  </h2>
-                  <Sparkles className="w-7 h-7 text-fuchsia-400 animate-pulse" />
-                </div>
-                
-                <p className="max-w-prose font-body text-white/80 text-lg leading-relaxed">
-                  Enter your birth details below to unlock your personalized astrological reading. 
-                  We'll create a comprehensive chart showing your planetary positions, houses, and karmic insights.
-                </p>
-
-                {/* Enhanced privacy assurance */}
-                <div className="inline-flex items-center gap-2 text-white/70 bg-slate-800/30 px-4 py-2 rounded-full border border-slate-600/30 backdrop-blur-sm">
-                  <Shield className="w-4 h-4 text-green-400" />
-                  <span className="text-sm font-medium">Your data is secure and only used to generate your chart</span>
-                </div>
-              </div>
-
-              {/* Enhanced card with better contrast */}
-              <Card className="bg-gradient-to-br from-slate-900/80 to-slate-800/60 border-2 border-fuchsia-500/30 shadow-2xl shadow-fuchsia-500/20 backdrop-blur-sm">
-                <BirthForm onSubmit={handleSubmit} initialValues={prefillValues} isSubmitting={submitting} />
-              </Card>
-
-              {/* Sample Data Buttons - enhanced styling */}
-              <div className="mt-10 p-8 bg-gradient-to-br from-fuchsia-500/10 to-purple-600/10 rounded-2xl border-2 border-fuchsia-500/20 backdrop-blur-sm shadow-xl">
-                <div className="text-center mb-6">
-                  <h3 className="text-lg font-semibold text-white/90 mb-2">Don't have your birth details handy?</h3>
-                  <p className="text-white/60 text-sm">Try with these famous personalities to explore the platform:</p>
-                </div>
-                <div className="flex justify-center">
-                  <SampleButtons onSelect={handlePrefill} onNewForm={handleNewForm} />
-                </div>
-              </div>
-
-              {/* Enhanced benefits preview */}
-              <div className="mt-12 text-center">
-                <div className="flex items-center justify-center gap-2 mb-6">
-                  <TrendingUp className="w-5 h-5 text-fuchsia-400" />
-                  <p className="text-white/80 text-lg font-semibold">
-                    After generating your chart, you'll receive:
-                  </p>
-                </div>
-                
-                <div className="grid grid-cols-2 md:grid-cols-4 gap-4 max-w-4xl mx-auto">
-                  <div className="bg-gradient-to-br from-fuchsia-500/20 to-purple-600/20 px-4 py-3 rounded-xl border border-fuchsia-500/30 backdrop-blur-sm">
-                    <span className="text-sm font-medium text-white/90">Birth Chart Visualization</span>
-                  </div>
-                  <div className="bg-gradient-to-br from-fuchsia-500/20 to-purple-600/20 px-4 py-3 rounded-xl border border-fuchsia-500/30 backdrop-blur-sm">
-                    <span className="text-sm font-medium text-white/90">Planetary Positions</span>
-                  </div>
-                  <div className="bg-gradient-to-br from-fuchsia-500/20 to-purple-600/20 px-4 py-3 rounded-xl border border-fuchsia-500/30 backdrop-blur-sm">
-                    <span className="text-sm font-medium text-white/90">Karmic Insights</span>
-                  </div>
-                  <div className="bg-gradient-to-br from-fuchsia-500/20 to-purple-600/20 px-4 py-3 rounded-xl border border-fuchsia-500/30 backdrop-blur-sm">
-                    <span className="text-sm font-medium text-white/90">Personalized Reading</span>
-                  </div>
-                </div>
-              </div>
-            </div>
-          </MotionFade>
+          <ChartForm onSubmit={handleSubmit} initialValues={prefillValues} isSubmitting={submitting} />
+          <DemoProfiles onSelect={handlePrefill} onNewForm={handleNewForm} />
+          <ValueGrid />
+          <PreviewSection wheelSrc={wheelSrc} />
         </section>
       </div>
 

--- a/karma-aligns-app/components/landing/ChartForm.tsx
+++ b/karma-aligns-app/components/landing/ChartForm.tsx
@@ -1,0 +1,40 @@
+'use client';
+
+import React from 'react';
+import Card from '@/components/ui/Card';
+import BirthForm, { BirthFormValues } from './BirthForm';
+import { Shield, Sparkles } from 'lucide-react';
+
+interface ChartFormProps {
+  onSubmit: (v: BirthFormValues) => void;
+  initialValues?: BirthFormValues;
+  isSubmitting?: boolean;
+}
+
+export default function ChartForm({ onSubmit, initialValues, isSubmitting }: ChartFormProps) {
+  return (
+    <div className="mx-auto max-w-2xl">
+      <div className="mb-10 space-y-6 text-center">
+        <div className="flex items-center justify-center gap-3 mb-6">
+          <Sparkles className="w-7 h-7 text-fuchsia-400 animate-pulse" />
+          <h2 className="text-3xl md:text-4xl font-heading font-bold text-white drop-shadow-lg">
+            Generate Your Chart
+          </h2>
+          <Sparkles className="w-7 h-7 text-fuchsia-400 animate-pulse" />
+        </div>
+        <p className="max-w-prose font-body text-white/80 text-lg leading-relaxed">
+          Enter your birth details below to unlock your personalized astrological reading.
+        </p>
+        <div className="inline-flex items-center gap-2 text-white/70 bg-slate-800/30 px-4 py-2 rounded-full border border-slate-600/30 backdrop-blur-sm">
+          <Shield className="w-4 h-4 text-green-400" />
+          <span className="text-sm font-medium">Your data is never stored, only used to generate your chart.</span>
+        </div>
+      </div>
+
+      <Card className="bg-gradient-to-br from-slate-900/80 to-slate-800/60 border-2 border-fuchsia-500/30 shadow-2xl shadow-fuchsia-500/20 backdrop-blur-sm">
+        <BirthForm onSubmit={onSubmit} initialValues={initialValues} isSubmitting={isSubmitting} />
+      </Card>
+    </div>
+  );
+}
+

--- a/karma-aligns-app/components/landing/DemoProfiles.tsx
+++ b/karma-aligns-app/components/landing/DemoProfiles.tsx
@@ -1,0 +1,25 @@
+'use client';
+
+import React from 'react';
+import SampleButtons from './SampleButtons';
+import { BirthFormValues } from './BirthForm';
+
+interface DemoProfilesProps {
+  onSelect: (v: BirthFormValues) => void;
+  onNewForm: () => void;
+}
+
+export default function DemoProfiles({ onSelect, onNewForm }: DemoProfilesProps) {
+  return (
+    <div className="mt-10 p-8 bg-gradient-to-br from-fuchsia-500/10 to-purple-600/10 rounded-2xl border-2 border-fuchsia-500/20 backdrop-blur-sm shadow-xl">
+      <div className="text-center mb-6">
+        <h3 className="text-lg font-semibold text-white/90 mb-2">Don&apos;t have your birth details handy?</h3>
+        <p className="text-white/60 text-sm">Try with these famous personalities to explore the platform:</p>
+      </div>
+      <div className="flex justify-center">
+        <SampleButtons onSelect={onSelect} onNewForm={onNewForm} />
+      </div>
+    </div>
+  );
+}
+

--- a/karma-aligns-app/components/landing/Hero.tsx
+++ b/karma-aligns-app/components/landing/Hero.tsx
@@ -1,0 +1,52 @@
+'use client';
+
+import Image from 'next/image';
+import React from 'react';
+
+interface HeroProps {
+  wheelSrc?: string;
+  onCTAClick?: () => void;
+}
+
+export default function Hero({ wheelSrc = '/karma-wheel.png', onCTAClick }: HeroProps) {
+  return (
+    <section className="relative flex min-h-screen items-center justify-center p-6">
+      <div className="grid w-full max-w-7xl gap-10 md:grid-cols-2">
+        {/* Left side: headline, subheading, CTA */}
+        <div className="flex flex-col justify-center space-y-6 text-center md:text-left">
+          <h1 className="font-heading text-5xl md:text-6xl lg:text-7xl font-bold leading-tight">
+            Balance your <span className="text-fuchsia-400 drop-shadow-[0_0_20px_rgba(217,70,239,0.5)]">Karma</span>
+            <br />
+            Align your <span className="text-fuchsia-400 drop-shadow-[0_0_20px_rgba(217,70,239,0.5)]">Life</span>
+          </h1>
+          <p className="max-w-xl mx-auto md:mx-0 text-white/80 text-lg">
+            Discover your unique cosmic blueprint with personalized insights.
+          </p>
+          <div>
+            <button
+              onClick={onCTAClick}
+              className="px-8 py-4 rounded-2xl bg-gradient-to-r from-fuchsia-500 to-purple-600 text-white font-semibold shadow-lg hover:shadow-xl transition-all duration-300 hover:scale-105 active:scale-95"
+            >
+              ✨ Generate My Chart
+            </button>
+          </div>
+        </div>
+
+        {/* Right side: zodiac wheel */}
+        <div className="flex items-center justify-center">
+          <div className="relative w-72 h-72 md:w-96 md:h-96">
+            <Image
+              src={wheelSrc}
+              alt="Zodiac wheel"
+              fill
+              priority
+              className="rounded-full opacity-95 spin-slow select-none"
+            />
+            <div className="absolute inset-0 rounded-full bg-[radial-gradient(circle_at_50%_50%,#8ecbff22,transparent_60%)]" />
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}
+

--- a/karma-aligns-app/components/landing/PreviewSection.tsx
+++ b/karma-aligns-app/components/landing/PreviewSection.tsx
@@ -1,0 +1,30 @@
+'use client';
+
+import Image from 'next/image';
+import React from 'react';
+
+export default function PreviewSection({ wheelSrc = '/karma-wheel.png' }: { wheelSrc?: string }) {
+  return (
+    <section className="mt-16">
+      <div className="mx-auto grid max-w-5xl items-center gap-12 px-4 md:grid-cols-2">
+        <div className="flex items-center justify-center">
+          <div className="relative w-64 h-64 md:w-80 md:h-80">
+            <Image src={wheelSrc} alt="Sample chart" fill className="rounded-full opacity-90" />
+          </div>
+        </div>
+        <div className="space-y-4 text-white/80">
+          <h3 className="text-2xl font-heading text-white">Why this matters</h3>
+          <ul className="list-disc pl-5 space-y-2 text-sm">
+            <li>Visualize your birth chart instantly.</li>
+            <li>Understand planetary influences.</li>
+            <li>Gain actionable karmic insights.</li>
+          </ul>
+          <button className="mt-4 px-6 py-3 rounded-2xl bg-gradient-to-r from-fuchsia-500 to-purple-600 text-white font-semibold hover:scale-105 active:scale-95 transition-all duration-300">
+            See My Cosmic Blueprint
+          </button>
+        </div>
+      </div>
+    </section>
+  );
+}
+

--- a/karma-aligns-app/components/landing/TrustStrip.tsx
+++ b/karma-aligns-app/components/landing/TrustStrip.tsx
@@ -1,0 +1,26 @@
+'use client';
+
+import { Award, Star, Users } from 'lucide-react';
+import React from 'react';
+
+export default function TrustStrip() {
+  const items = [
+    { icon: <Users className="w-4 h-4" />, text: '1000+ charts generated' },
+    { icon: <Star className="w-4 h-4 text-yellow-400" />, text: '4.9/5 rating' },
+    { icon: <Award className="w-4 h-4" />, text: 'AI-powered insights' },
+  ];
+
+  return (
+    <div className="w-full bg-black/30 backdrop-blur-sm border-t border-b border-white/10 py-3">
+      <div className="mx-auto flex max-w-3xl items-center justify-center gap-6 text-sm text-white/80">
+        {items.map((item, idx) => (
+          <div key={idx} className="flex items-center gap-1">
+            {item.icon}
+            <span>{item.text}</span>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+

--- a/karma-aligns-app/components/landing/ValueGrid.tsx
+++ b/karma-aligns-app/components/landing/ValueGrid.tsx
@@ -1,0 +1,29 @@
+'use client';
+
+import React from 'react';
+import { ScrollText, Planet, Sparkles, Telescope } from 'lucide-react';
+
+export default function ValueGrid() {
+  const items = [
+    { icon: <ScrollText className="w-6 h-6" />, label: 'Birth Chart Visualization' },
+    { icon: <Planet className="w-6 h-6" />, label: 'Planetary Positions' },
+    { icon: <Sparkles className="w-6 h-6" />, label: 'Karmic Insights' },
+    { icon: <Telescope className="w-6 h-6" />, label: 'Personalized Reading' },
+  ];
+  return (
+    <div className="mt-12 text-center">
+      <div className="flex items-center justify-center gap-2 mb-6">
+        <p className="text-white/80 text-lg font-semibold">What you&apos;ll receive:</p>
+      </div>
+      <div className="grid grid-cols-2 md:grid-cols-4 gap-4 max-w-4xl mx-auto">
+        {items.map((item, idx) => (
+          <div key={idx} className="bg-gradient-to-br from-fuchsia-500/20 to-purple-600/20 px-4 py-3 rounded-xl border border-fuchsia-500/30 backdrop-blur-sm flex flex-col items-center gap-2">
+            {item.icon}
+            <span className="text-sm font-medium text-white/90">{item.label}</span>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+


### PR DESCRIPTION
## Summary
- Break landing page into modular components: Hero, TrustStrip, ChartForm, DemoProfiles, ValueGrid, and PreviewSection.
- Restore cosmic background elements by layering Moon and ConstellationOverlay alongside Starfield, AmbientBodies, and ShootingStars.

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 27 errors, e.g., unexpected `any` types in `components/results/AstrochartTimeline.tsx`)*

------
https://chatgpt.com/codex/tasks/task_e_68c5375c2fd4832c8acf935e24d7e9ce