### PR TITLE
Replace invalid Planet icon in ValueGrid

### DIFF
--- a/karma-aligns-app/components/landing/ValueGrid.tsx
+++ b/karma-aligns-app/components/landing/ValueGrid.tsx
@@ -1,12 +1,12 @@
 'use client';
 
 import React from 'react';
-import { ScrollText, Planet, Sparkles, Telescope } from 'lucide-react';
+import { ScrollText, Globe, Sparkles, Telescope } from 'lucide-react';
 
 export default function ValueGrid() {
   const items = [
     { icon: <ScrollText className="w-6 h-6" />, label: 'Birth Chart Visualization' },
-    { icon: <Planet className="w-6 h-6" />, label: 'Planetary Positions' },
+    { icon: <Globe className="w-6 h-6" />, label: 'Planetary Positions' },
     { icon: <Sparkles className="w-6 h-6" />, label: 'Karmic Insights' },
     { icon: <Telescope className="w-6 h-6" />, label: 'Personalized Reading' },
   ];


### PR DESCRIPTION
## Summary
- replace deprecated Planet icon with Globe from lucide-react
- update Planetary Positions grid item to use Globe icon

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Unexpected any and other lint errors)*
- `npm run build` *(fails: Failed to fetch `Merriweather` from Google Fonts)*

------
https://chatgpt.com/codex/tasks/task_e_68c5407dd614832ca9433db8db3a5529